### PR TITLE
Fix intelligence calculation

### DIFF
--- a/idle-rpg/utils/helper.js
+++ b/idle-rpg/utils/helper.js
@@ -120,11 +120,11 @@ class helper {
   }
 
   sumPlayerTotalIntelligence(player) {
-    return (player.stats.int
+    return player.stats.int
       + player.equipment.helmet.int
       + player.equipment.armor.int
       + player.equipment.weapon.int
-      + player.equipment.relic.int) / 2;
+      + player.equipment.relic.int;
   }
 
   sumPlayerTotalLuck(player) {


### PR DESCRIPTION
We already divide intelligence by two in `battle` events. Doing this two times causes intelligence go lower even than flat gain from level.

For example my intelligence in battle is ~3,5 even though my flat intelligence is 9.

