### PR TITLE
rework(Commands): modifyPM with enums

### DIFF
--- a/idle-rpg/bots/data/commands.js
+++ b/idle-rpg/bots/data/commands.js
@@ -793,23 +793,23 @@ const commands = [
       const { Game, messageObj } = params;
       if (messageObj.content.includes(' ')) {
         const splitCommand = messageObj.content.split(/ (.+)/);
+        let pmMode;
         switch (splitCommand[1].toLowerCase()) {
           case 'on':
+            pmMode = enumHelper.pmMode.on;
+            break;
           case 'off':
-            return Game.fetchCommand({
-              command: 'modifyPM',
-              author: messageObj.author,
-              value: splitCommand[1] === 'on',
-              filtered: false
-            });
+            pmMode = enumHelper.pmMode.off;
+            break;
           case 'filtered':
-            return Game.fetchCommand({
-              command: 'modifyPM',
-              author: messageObj.author,
-              value: true,
-              filtered: true
-            });
+            pmMode = enumHelper.pmMode.filtered
+            break;
         }
+        return Game.fetchCommand({
+          command: 'modifyPM',
+          author: messageObj.author,
+          value: pmMode
+        });
       }
 
       return messageObj.author.send(`\`\`\`Possible options:

--- a/idle-rpg/bots/data/commands.js
+++ b/idle-rpg/bots/data/commands.js
@@ -793,23 +793,16 @@ const commands = [
       const { Game, messageObj } = params;
       if (messageObj.content.includes(' ')) {
         const splitCommand = messageObj.content.split(/ (.+)/);
-        let pmMode;
         switch (splitCommand[1].toLowerCase()) {
-          case 'on':
-            pmMode = enumHelper.pmMode.on;
-            break;
-          case 'off':
-            pmMode = enumHelper.pmMode.off;
-            break;
-          case 'filtered':
-            pmMode = enumHelper.pmMode.filtered
-            break;
+          case enumHelper.pmMode.on:
+          case enumHelper.pmMode.off:
+          case enumHelper.pmMode.filtered:
+            return Game.fetchCommand({
+              command: 'modifyPM',
+              author: messageObj.author,
+              value: splitCommand[1].toLowerCase()
+            });
         }
-        return Game.fetchCommand({
-          command: 'modifyPM',
-          author: messageObj.author,
-          value: pmMode
-        });
       }
 
       return messageObj.author.send(`\`\`\`Possible options:

--- a/idle-rpg/database/schemas/player.js
+++ b/idle-rpg/database/schemas/player.js
@@ -105,12 +105,8 @@ const playerSchema = mongoose.Schema({
     default: 'on'
   },
   isPrivateMessage: {
-    type: Boolean,
-    default: false
-  },
-  isPrivateMessageImportant: {
-    type: Boolean,
-    default: false
+    type: String,
+    default: 'off'
   },
   gender: {
     type: String,
@@ -302,8 +298,7 @@ const newPlayerObj = (discordId, guildId, name) => {
       dailyLottery: 0
     },
     isMentionInDiscord: guildId === '390509935097675777' ? 'on' : 'off',
-    isPrivateMessage: false,
-    isPrivateMessageImportant: false,
+    isPrivateMessage: 'off',
     gender: 'neutral',
     equipment: {
       helmet: equipment.empty.helmet,

--- a/idle-rpg/utils/enumHelper.js
+++ b/idle-rpg/utils/enumHelper.js
@@ -11,6 +11,12 @@ const enumHelper = {
     'dnd'
   ],
 
+  pmMode: {
+    on: 'on',
+    off: 'off',
+    filtered: 'filtered'
+  },
+
   map: {
     types: {
       town: 'Town'

--- a/idle-rpg/v2/Base/Discord.js
+++ b/idle-rpg/v2/Base/Discord.js
@@ -1,5 +1,5 @@
 const { infoLog, actionLog, moveLog } = require('../../utils/logger');
-const { enumHelper } = require('../../utils/enumHelper');
+const enumHelper = require('../../utils/enumHelper');
 
 class Discord {
 

--- a/idle-rpg/v2/Base/Discord.js
+++ b/idle-rpg/v2/Base/Discord.js
@@ -1,5 +1,5 @@
 const { infoLog, actionLog, moveLog } = require('../../utils/logger');
-const { playableStatus } = require('../../utils/enumHelper');
+const { enumHelper } = require('../../utils/enumHelper');
 
 class Discord {
 
@@ -206,12 +206,11 @@ There's a command to get the invite link !invite`);
       if (channelToSend) {
         await channelToSend.send(message, { split: true });
       }
-      if (result.updatedPlayer.isPrivateMessage && result.updatedPlayer.isPrivateMessageImportant && result.type === 'actions'
-        || result.updatedPlayer.isPrivateMessage && !result.updatedPlayer.isPrivateMessageImportant) {
+      if (result.updatedPlayer.isPrivateMessage === enumHelper.pmMode.on || (result.updatedPlayer.isPrivateMessage === enumHelper.pmMode.filtered && result.type === 'actions')) {
         const guildMember = await guild.members.find(member => member.id === result.updatedPlayer.discordId);
         await guildMember.send(privateMessage, { split: true });
       }
-      if (result.attackerObj && result.attackerObj.isPrivateMessage && result.otherPlayerPmMsg) {
+      if (result.attackerObj && result.attackerObj.isPrivateMessage === enumHelper.pmMode.on && result.otherPlayerPmMsg) {
         const otherPlayerPrivateMessage = result.otherPlayerPmMsg.join('\n');
         const guildMember = await guild.members.find(member => member.id === result.attackerObj.discordId);
         await guildMember.send(otherPlayerPrivateMessage, { split: true });

--- a/idle-rpg/v2/idle-rpg/data/Commands.js
+++ b/idle-rpg/v2/idle-rpg/data/Commands.js
@@ -329,7 +329,7 @@ ${rankString}\`\`\``);
       return author.send('Please set this after you have been born');
     }
 
-    if (loadedPlayer.isPrivateMessage === value || loadedPlayer.isPrivateMessageImportant === filtered) {
+    if (!filtered && !loadedPlayer.isPrivateMessageImportant && loadedPlayer.isPrivateMessage === value || filtered && loadedPlayer.isPrivateMessageImportant === filtered) {
       return author.send('Your PM preference is already set to this value.');
     }
     loadedPlayer.isPrivateMessage = value;

--- a/idle-rpg/v2/idle-rpg/data/Commands.js
+++ b/idle-rpg/v2/idle-rpg/data/Commands.js
@@ -336,7 +336,7 @@ ${rankString}\`\`\``);
 
     await this.Database.savePlayer(loadedPlayer);
 
-    return author.send('Preference for being PMed has been updated.');
+    return author.send(`Preference for being PMed has been set to ${value}.`);
   }
 
   async modifyMention(params) {

--- a/idle-rpg/v2/idle-rpg/data/Commands.js
+++ b/idle-rpg/v2/idle-rpg/data/Commands.js
@@ -323,17 +323,17 @@ ${rankString}\`\`\``);
   }
 
   async modifyPM(params) {
-    const { author, value, filtered } = params;
+    const { author, value } = params;
     const loadedPlayer = await this.Database.loadPlayer(author.id, { pastEvents: 0, pastPvpEvents: 0 });
     if (!loadedPlayer) {
       return author.send('Please set this after you have been born');
     }
 
-    if (!filtered && !loadedPlayer.isPrivateMessageImportant && loadedPlayer.isPrivateMessage === value || filtered && loadedPlayer.isPrivateMessageImportant === filtered) {
+    if (loadedPlayer.isPrivateMessage === value) {
       return author.send('Your PM preference is already set to this value.');
     }
     loadedPlayer.isPrivateMessage = value;
-    loadedPlayer.isPrivateMessageImportant = filtered;
+
     await this.Database.savePlayer(loadedPlayer);
 
     return author.send('Preference for being PMed has been updated.');

--- a/idle-rpg/v2/idle-rpg/data/Commands.js
+++ b/idle-rpg/v2/idle-rpg/data/Commands.js
@@ -245,14 +245,14 @@ ${rankString}\`\`\``);
           guildConfig.multiplier += calcAmount;
           guildConfig.spells.activeBless += calcAmount;
           await this.Database.updateGame(player.guildId, guildConfig);
-          actionsChannel.send(this.Helper.setImportantMessage(`${player.name}${player.titles.current !== 'None' ? ` the ${player.titles.current}` : ''} just cast${calcAmount > 1 ? ` ${calcAmount}x` : ' '}${spell}!!\nCurrent Active Bless: ${guildConfig.spells.activeBless}\nCurrent Multiplier is: ${guildConfig.multiplier}x`));
+          actionsChannel.send(this.Helper.setImportantMessage(`${player.name}${player.titles.current !== 'None' ? ` the ${player.titles.current}` : ''} just cast${calcAmount > 1 ? ` ${calcAmount}x ` : ' '}${spell}!!\nCurrent Active Bless: ${guildConfig.spells.activeBless}\nCurrent Multiplier is: ${guildConfig.multiplier}x`));
           setTimeout(async () => {
             const newLoadedConfig = await this.Database.loadGame(player.guildId);
             newLoadedConfig.multiplier -= calcAmount;
             newLoadedConfig.spells.activeBless -= calcAmount;
             newLoadedConfig.spells.multiplier = newLoadedConfig.spells.multiplier <= 0 ? 1 : newLoadedConfig.spells.multiplier;
             await this.Database.updateGame(player.guildId, newLoadedConfig);
-            actionsChannel.send(this.Helper.setImportantMessage(`${player.name}${player.titles.current !== 'None' ? ` the ${player.titles.current}` : ''}s${calcAmount > 1 ? ` ${calcAmount}x` : ' '}${spell} just wore off.\nCurrent Active Bless: ${newLoadedConfig.spells.activeBless}\nCurrent Multiplier is: ${newLoadedConfig.multiplier}x`));
+            actionsChannel.send(this.Helper.setImportantMessage(`${player.name}${player.titles.current !== 'None' ? ` the ${player.titles.current}` : ''}s${calcAmount > 1 ? ` ${calcAmount}x ` : ' '}${spell} just wore off.\nCurrent Active Bless: ${newLoadedConfig.spells.activeBless}\nCurrent Multiplier is: ${newLoadedConfig.multiplier}x`));
           }, 1800000); // 30 minutes
         } else {
           author.send(`You do not have enough gold! This spell costs ${globalSpells.bless.spellCost} gold. You're lacking ${globalSpells.bless.spellCost - player.gold.current} gold.`);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start:windows": "SET NODE_ENV=production && node app.js",
     "start": "NODE_ENV=production node app.js",
-	"test:windows": "SET NODE_ENV=development && node app.js",
+    "test:windows": "SET NODE_ENV=development && node app.js",
     "test": "NODE_ENV=development node app.js"
   },
   "author": "Sunny Huang",


### PR DESCRIPTION
Instead of #188 
It should be clearer now.

We would also have to change the isPrivateMessage value corresponding to the old values:

| isPrivateMessage | isPrivateMessageImportant  | new isPrivateMessage |
| --- | --- | --- |
| true | false | on |
| false  | false  | off |
| true | true  | filtered |

Easiest solution probably would be using this only after the reset.

Another thing would be removing the now unused isPrivateMessageImportant from the db.