### PR TITLE
Add Heroku deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To see this bot in action it is currently running at the [Idle-RPG Discord Serve
 
 There is also a [Idle-RPG Trello Board](https://trello.com/b/OnpWqvlp/idle-rpg)
 
-## Deploy AvaIre on Heroku
+## Deploy Idle-RPG-Bot on Heroku
 You can deploy in a simple way to Heroku using the button below.
 
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ To see this bot in action it is currently running at the [Idle-RPG Discord Serve
 
 There is also a [Idle-RPG Trello Board](https://trello.com/b/OnpWqvlp/idle-rpg)
 
+## Deploy AvaIre on Heroku
+You can deploy in a simple way to Heroku using the button below.
+
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
 # Setup
 Create a .env file in the project root directory with these env variables: (Without < >)
 ```

--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
     "repository": "https://github.com/sizzlorox/Idle-RPG-Bot",
     "addons": [
         {
-            "plan": "jawsdb:kitefin"
+            "plan": "mongolab:sandbox"
         }
     ],
     "env": {

--- a/app.json
+++ b/app.json
@@ -32,12 +32,12 @@
         "MIN_TIMER": {
             "description": "Minimal Timer in minutes",
             "required": true,
-            "value": "avaire/avaire"
+            "value": "2"
         },
         "MAX_TIMER": {
             "description": "Maximum Timer in minutes",
             "required": true,
-            "value": "master"
+            "value": "5"
         }
     },
     "formation": {

--- a/app.json
+++ b/app.json
@@ -1,0 +1,58 @@
+{
+    "name": "Idle-RPG-Bot",
+    "description": "This is a project to practice and learn more on how to create a bot for Discord and to practice javascript. Anybody who is willing to join in on this project is welcome to do so!",
+    "keywords": [
+        "Heroku",
+        "Idle-RPG-Bot",
+        "Idle-RPG",
+        "Discord Bot",
+        "Entertainment",
+        "RPG",
+        "Moderation",
+        "sizzlorox",
+        "JavaScript",
+        "Selfhosting"
+    ],
+    "repository": "https://github.com/sizzlorox/Idle-RPG-Bot",
+    "addons": [
+        {
+            "plan": "jawsdb:kitefin"
+        }
+    ],
+    "env": {
+        "DISCORD_BOT_LOGIN_TOKEN": {
+            "description": "Get your BOT TOKEN from https://discordapp.com/developers/applications/.",
+            "required": true
+        },
+        "DISCORD_BOT_OPERATORS_ID": {
+            "description": "Specifies which users can use the system commands of Avaire. You can add multiple by doing: <userid>, <seconduserid>.",
+            "required": false,
+            "value": "123456789, 987654321"
+        },
+        "MIN_TIMER": {
+            "description": "Minimal Timer in minutes",
+            "required": true,
+            "value": "avaire/avaire"
+        },
+        "MAX_TIMER": {
+            "description": "Maximum Timer in minutes",
+            "required": true,
+            "value": "master"
+        }
+    },
+    "formation": {
+        "worker": {
+            "quantity": 1,
+            "size": "free"
+        },
+        "web": {
+            "quantity": 0,
+            "size": "free"
+        }
+    },
+    "buildpacks": [
+        {
+            "url": "heroku/nodejs"
+        }
+    ]
+}

--- a/app.json
+++ b/app.json
@@ -25,7 +25,7 @@
             "required": true
         },
         "DISCORD_BOT_OPERATORS_ID": {
-            "description": "Specifies which users can use the system commands of Avaire. You can add multiple by doing: <userid>, <seconduserid>.",
+            "description": "Specifies which users can use the system commands of Idle-RPG-Bot. You can add multiple by doing: <userid>, <seconduserid>.",
             "required": false,
             "value": "123456789, 987654321"
         },

--- a/settings.js
+++ b/settings.js
@@ -10,7 +10,7 @@ const settings = {
   minimalTimer: process.env.NODE_ENV.includes('production') ? process.env.MIN_TIMER : process.env.TEST_MIN_TIMER,
   maximumTimer: process.env.NODE_ENV.includes('production') ? process.env.MAX_TIMER : process.env.TEST_MAX_TIMER,
   botOperators: process.env.DISCORD_BOT_OPERATORS_ID.replace(' ', '').split(','),
-  mongoDBUri: process.env.MONGODB_URI ? process.env.JAWSDB_URL,
+  mongoDBUri: process.env.MONGODB_URI ? process.env.MONGODB_URI : process.env.JAWSDB_URL,
   starterTown: [3, 5],
   multiplier: 1
 };

--- a/settings.js
+++ b/settings.js
@@ -11,6 +11,7 @@ const settings = {
   maximumTimer: process.env.NODE_ENV.includes('production') ? process.env.MAX_TIMER : process.env.TEST_MAX_TIMER,
   botOperators: process.env.DISCORD_BOT_OPERATORS_ID.replace(' ', '').split(','),
   mongoDBUri: process.env.MONGODB_URI,
+  JAWSDB_URL: process.env.MONGODB_URI,
   starterTown: [3, 5],
   multiplier: 1
 };

--- a/settings.js
+++ b/settings.js
@@ -10,7 +10,7 @@ const settings = {
   minimalTimer: process.env.NODE_ENV.includes('production') ? process.env.MIN_TIMER : process.env.TEST_MIN_TIMER,
   maximumTimer: process.env.NODE_ENV.includes('production') ? process.env.MAX_TIMER : process.env.TEST_MAX_TIMER,
   botOperators: process.env.DISCORD_BOT_OPERATORS_ID.replace(' ', '').split(','),
-  mongoDBUri: process.env.MONGODB_URI ? process.env.MONGODB_URI : process.env.JAWSDB_URL,
+  mongoDBUri: process.env.MONGODB_URI ? process.env.MONGODB_URI : process.env.MONGOLAB_AMBER_URI,
   starterTown: [3, 5],
   multiplier: 1
 };

--- a/settings.js
+++ b/settings.js
@@ -10,8 +10,7 @@ const settings = {
   minimalTimer: process.env.NODE_ENV.includes('production') ? process.env.MIN_TIMER : process.env.TEST_MIN_TIMER,
   maximumTimer: process.env.NODE_ENV.includes('production') ? process.env.MAX_TIMER : process.env.TEST_MAX_TIMER,
   botOperators: process.env.DISCORD_BOT_OPERATORS_ID.replace(' ', '').split(','),
-  mongoDBUri: process.env.MONGODB_URI,
-  JAWSDB_URL: process.env.MONGODB_URI,
+  mongoDBUri: process.env.MONGODB_URI ? process.env.JAWSDB_URL,
   starterTown: [3, 5],
   multiplier: 1
 };


### PR DESCRIPTION
This pull adds a env variable for jawsdb, this makes the database part automatically for the user ready.
The app.json specifies the env variables and the buildpacks needed to compile the bot.
The readme is updated with the button, this should mean when this is merged, the button will redirect to the heroku website, where the following should be displayed https://imgur.com/cDewwwu.png